### PR TITLE
Handle global constructors for C++ applications

### DIFF
--- a/asp3/target/primehub_gcc/stm32f413xx.ld
+++ b/asp3/target/primehub_gcc/stm32f413xx.ld
@@ -25,6 +25,14 @@ SECTIONS
 		*(.rodata.*)
 	} > FLASH
 
+	.init_array : ALIGN(4)
+	{
+		_init_array_start = .;
+		KEEP (*(SORT(.init_array.*)))
+		KEEP (*(.init_array))
+		_init_array_end = .;
+	} > FLASH
+
 	.ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) }
 	__exidx_start = .;
 	.ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -38,9 +38,11 @@ INCLUDES += -I$(DRIVERS_DIR) \
 #
 # Definitions for libcpp/spike
 #
+KERNEL_COBJS += app_init.o
 KERNEL_CXXOBJS += Button.o Clock.o IMU.o Light.o
 KERNEL_DIRS += $(DRIVERS_DIR)/libcpp \
 	       $(DRIVERS_DIR)/libcpp/spike
+INCLUDES += -I$(DRIVERS_DIR)/libcpp
 
 #
 #  Definitions for Pybricks.

--- a/drivers/drivers.cfg
+++ b/drivers/drivers.cfg
@@ -11,3 +11,4 @@ ATT_INI({TA_NULL, 0, newlib_tlsf_init});
 CRE_SEM(APP_HEAP_SEM, {TA_TPRI, 1, 1});
 
 INCLUDE("pybricks.cfg");
+INCLUDE("libcpp/app_init.cfg");

--- a/drivers/libcpp/app_init.c
+++ b/drivers/libcpp/app_init.c
@@ -1,0 +1,19 @@
+#include "app_init.h"
+
+void _app_init_task(intptr_t unused) {
+
+  // Call C++ global constructors
+  typedef void (* constructor_t)(void);
+  extern constructor_t _init_array_start[]; // cf. linker script
+  extern constructor_t _init_array_end[];   // in asp3/target/primehub_gcc/stm32f413xx.ld
+  constructor_t *fn = _init_array_start;
+  while (fn < _init_array_end) {
+    (*fn++)();
+  }
+}
+
+#if 0
+// cf. http://wiki.osdev.org/Calling_Global_Constructors
+void __attribute__((weak)) _fini() {}
+void *__dso_handle __attribute__((weak))=0;
+#endif

--- a/drivers/libcpp/app_init.cfg
+++ b/drivers/libcpp/app_init.cfg
@@ -1,0 +1,3 @@
+#include "app_init.h"
+CRE_TSK(APP_INIT_TASK, { TA_ACT, 0, _app_init_task, TPRI_APP_INIT_TASK, 4096, NULL });
+

--- a/drivers/libcpp/app_init.h
+++ b/drivers/libcpp/app_init.h
@@ -1,0 +1,6 @@
+/**
+ * Application initialize task
+ */
+#include <kernel.h>
+#define TPRI_APP_INIT_TASK (TMIN_TPRI + 7)
+extern void _app_init_task(intptr_t unused);


### PR DESCRIPTION
libcpp を使うC++アプリのコンストラクタが呼ばれていなかったため、呼び出す部分を追加しました。EV3RTのev3api.cに倣って、初期化タスクを走らせています。